### PR TITLE
修复：对所有 API 请求使用 HTTPS

### DIFF
--- a/xuechebu_crack.py
+++ b/xuechebu_crack.py
@@ -11,7 +11,7 @@ USER_INFO_CORRECT = True
 
 
 def get_unfinished_list(session):
-    url = 'http://xcbapi.xuechebu.com/videoApi/video/GetChapterList?os=pc'
+    url = 'https://xcbapi.xuechebu.com/videoApi/video/GetChapterList?os=pc'
 
     unfinished = []
 
@@ -42,7 +42,7 @@ def get_unfinished_list(session):
 
 
 def finish_chapter(session, chapter):
-    url = 'http://xcbapi.xuechebu.com/videoApi/student/UpdatePlay'
+    url = 'https://xcbapi.xuechebu.com/videoApi/student/UpdatePlay'
 
     data = {
         'os': 'pc',
@@ -68,7 +68,7 @@ def finish_chapter(session, chapter):
 
 
 def get_should_chapter(session):
-    url = 'http://xcbapi.xuechebu.com/videoApi/video/GetShouldChapter?os=pc'
+    url = 'https://xcbapi.xuechebu.com/videoApi/video/GetShouldChapter?os=pc'
 
     try:
         r = session.get(url)


### PR DESCRIPTION
### 问题描述

此 PR 修复了一个导致脚本无法成功运行的关键错误。在尝试获取课程数据时，脚本总是会因为 `403 Forbidden` 错误而执行失败。

### 问题原因

根本原因是 `xcbapi.xuechebu.com` 的 API 端点被通过未加密的 `http` 协议调用。服务器现在要求对这些端点使用安全的 `https` 连接，因此拒绝了不安全的请求。

### 解决方案

此修复将脚本中所有对 `xcbapi.xuechebu.com` 域的调用地址更新为 `https`。这符合了服务器的安全要求，并解决了 `403` 错误。

通过此更改，脚本可以再次成功登录、获取课程列表并按预期完成学习任务。